### PR TITLE
Added Bing Search Engine, 10X Speedup, Cleaner HTML. Made architectural changes requested by JulesGM

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ alt="Shows lines with search results, the titles and the urls.">
 
 - Uses `html2text` to strip the markup out of the page.
 - Uses `beautifulsoup4` to parse the title.
-- Currently only uses the `googlesearch` module to query Google for urls, but is coded
-in a modular / search engine agnostic way to allow very easily add new search engine support.
+- Supports both Google (default) and Bing search, but is coded in a modular / search engine agnostic 
+way to allow very easily add new search engine support. Bing search requires a API subscription key, 
+which can be obtained for free at: https://www.microsoft.com/en-us/bing/apis/bing-entity-search-api
 
 
 Using the `googlesearch` module is very slow because it parses Google search webpages instead of querying cloud webservices. This is fine for playing with the model, but makes that searcher unusable for training or large scale inference purposes. In the paper, Bing cloud services are used, matching the results over Common Crawl instead of just downloading the page.
@@ -61,4 +62,45 @@ python search_server.py test_server --host 0.0.0.0:8080
 
 ```bash
 python search_server.py test_parser www.some_url_of_your_choice.com/
+```
+
+# Additional Command Line Parameters
+
+- requests_get_timeout - sets the timeout for URL requests to fetch content of URLs found during search. Defaults to 5 seconds.
+- strip_html_menus - removes likely HTML menus to clean up text. This returns significantly higher quality and informationally dense text. 
+- max_text_bytes limits the bytes returned per web page. Defaults to no max.  Note, ParlAI current defaults to only use the first 512 byte. 
+- search_engine set to "Google" default or "Bing". Note, the Bing Search engine was used in the Blenderbot2 paper to achieve their results.  This implementation not only uses web pages but also news, entities and places.
+- use_description_only are short but 10X faster since no url gets for Bing only. It also has the advantage of being very concise without an HTML irrelevant text normally returned.
+- use_subscription_key required to use Bing only. Can get a free one at: https://www.microsoft.com/en-us/bing/apis/bing-entity-search-api
+
+# Advanced Examples
+
+Google Search Engine returning more relevant information than the defaults:
+```bash
+python search_server.py serve --host 0.0.0.0:8080 --max_text_bytes 512 --requests_get_timeout 10 --strip_html_menus
+```
+
+Bing Search Engine:
+```bash
+python search_server.py serve --host 0.0.0.0:8080 --search_engine="Bing" --subscription_key "put your bing api subscription key here"
+```
+
+Bing Search Engine returning more relevant information:
+```bash
+python search_server.py serve --host 0.0.0.0:8080 --search_engine="Bing" --max_text_bytes=512 --requests_get_timeout 10 --strip_html_menus --subscription_key "put your bing api subscription key here"
+```
+
+Bing Search Engine returning very relevant concise information 10X faster:
+```bash
+python search_server.py serve --host 0.0.0.0:8080 --search_engine="Bing" --use_description_only --subscription_key "put your bing api subscription key here"
+```
+
+# Additional Command Line Example Test Calls
+
+```bash
+curl -X POST "http://0.0.0:8080" -d "q=Which%20team%20does%20Tom%20Brady%20play%20for%20now&n=6"
+```
+
+```bash
+curl -X POST "http://0.0.0:8080" -d "q=Where%20Are%20The%20Olympics%20Being%20Held%20in%202021&n=6"
 ```

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Bing Search Engine returning more relevant information:
 python search_server.py serve --host 0.0.0.0:8080 --search_engine="Bing" --max_text_bytes=512 --requests_get_timeout 10 --strip_html_menus --subscription_key "put your bing api subscription key here"
 ```
 
-Bing Search Engine returning very relevant concise information 10X faster:
+Bing Search Engine returning very relevant concise information 10X faster. Returns a 250 to 350 byte web page summary per URL including the web page title:
 ```bash
 python search_server.py serve --host 0.0.0.0:8080 --search_engine="Bing" --use_description_only --subscription_key "put your bing api subscription key here"
 ```

--- a/search_server.py
+++ b/search_server.py
@@ -19,7 +19,6 @@ import rich
 import rich.markup
 import requests
 
-
 print = rich.print
 
 _DEFAULT_HOST = "0.0.0.0"
@@ -29,12 +28,22 @@ _STYLE_GOOD = "[green]"
 _STYLE_SKIP = ""
 _CLOSE_STYLE_GOOD = "[/]" if _STYLE_GOOD else ""
 _CLOSE_STYLE_SKIP = "[/]" if _STYLE_SKIP else ""
-_DEFAULT_URL_REQUEST_TIMEOUT = 15 # seconds
-_TRUNCATE_TEXT_BYTES = 2048
+_requests_get_timeout = 5 # seconds
+_strip_html_menus = False 
+_max_text_bytes = None  
+
+# To get a free Bing Subscription Key go here:
+#    https://www.microsoft.com/en-us/bing/apis/bing-entity-search-api
+_use_bing = False # Use Bing instead of Google Search Engine
+
+_use_bing_description_only = False # short but 10X faster
+
+# Bing Search API documentation:
+# https://docs.microsoft.com/en-us/bing/search-apis/bing-web-search/reference/query-parameters
 
 def _parse_host(host: str) -> Tuple[str, int]:
-    """ Parse the host string. 
-    Should be in the format HOSTNAME:PORT. 
+    """ Parse the host string.
+    Should be in the format HOSTNAME:PORT.
     Example: 0.0.0.0:8080
     """
     splitted = host.split(":")
@@ -46,15 +55,17 @@ def _parse_host(host: str) -> Tuple[str, int]:
 def _get_and_parse(url: str) -> Dict[str, str]:
     """ Download a webpage and parse it. """
 
+    global _requests_get_timeout
+
     try:
-        resp = requests.get(url, timeout=_DEFAULT_URL_REQUEST_TIMEOUT)
+        resp = requests.get(url, timeout=_requests_get_timeout)
     except requests.exceptions.RequestException as e:
         print(f"[!] {e} for url {url}")
         return None
     else:
         resp.encoding = resp.apparent_encoding
         page = resp.text
-    
+
     ###########################################################################
     # Prepare the title
     ###########################################################################
@@ -64,7 +75,7 @@ def _get_and_parse(url: str) -> Dict[str, str]:
     output_dict["title"] = (
         html.unescape(pre_rendered.renderContents().decode()) if pre_rendered else ""
     )
-    
+
     output_dict["title"] = (
         output_dict["title"].replace("\n", "").replace("\r", "")
     )
@@ -85,6 +96,8 @@ def _get_and_parse(url: str) -> Dict[str, str]:
 
 class SearchABC(http.server.BaseHTTPRequestHandler):
     def do_POST(self):
+        global _strip_html_menus, _max_text_bytes, _use_bing, _use_bing_description_only
+
         """ Handle POST requests from the client. (All requests are POST) """
 
         #######################################################################
@@ -112,16 +125,34 @@ class SearchABC(http.server.BaseHTTPRequestHandler):
         #######################################################################
         # Search, get the pages and parse the content of the pages
         #######################################################################
-        print(f"\n[bold]Received query:[/] {parsed}")
+        if _use_bing:
+            search_engine = "Bing"
+        else:
+            search_engine = "Google"
+
+        print(f"\n[bold]Received query:[/] {parsed}, using {search_engine} search engine and using bing link descriptions only {_use_bing_description_only}")
+
         n = int(parsed["n"])
         q = parsed["q"]
 
         # Over query a little bit in case we find useless URLs
         content = []
         dupe_detection_set = set()
-        
-        # Search until we have n valid entries
-        for url in self.search(q=q, n=n):
+
+        urls = []
+        if _use_bing:
+            results = self.search_bing(q, n, ["News", "Entities", "Places", "Webpages"],
+                _use_bing_description_only)
+
+            if _use_bing_description_only:
+                content = results
+            else:
+                urls = results
+        else:
+            urls = self.search(q=q, n=n)
+
+        # Only execute loop to fetch each URL if urls returned
+        for url in urls:
             if len(content) >= n:
                 break
 
@@ -141,7 +172,7 @@ class SearchABC(http.server.BaseHTTPRequestHandler):
             else:
                 reason_content_empty = False
                 reason_already_seen_content = False
-            
+
             reasons = dict(
                 reason_empty_response=reason_empty_response,
                 reason_content_empty=reason_content_empty,
@@ -163,9 +194,21 @@ class SearchABC(http.server.BaseHTTPRequestHandler):
                     # f"Content: {len(maybe_content['content'])}",
                 )
 
-                # Truncate text 
-                if len(maybe_content) > _TRUNCATE_TEXT_BYTES:
-                    maybe_content = maybe_content[:_TRUNCATE_TEXT_BYTES]
+                # Strip out all lines starting with "* " usually menu items
+                if _strip_html_menus:
+                    print("Stripping HTML menus")
+                    new_content = ""
+                    for line in maybe_content['content'].splitlines():
+                        x = re.findall("^[\s]*\\* ", line)
+                        if not x or len(line) > 50:
+                            new_content += line + "\n"
+
+                    maybe_content['content'] = new_content
+                else:
+                    print("Not stripping HTML menus")
+
+                # Truncate text
+                maybe_content['content'] = maybe_content['content'][:_max_text_bytes]
 
                 dupe_detection_set.add(maybe_content["content"])
                 content.append(maybe_content)
@@ -184,12 +227,12 @@ class SearchABC(http.server.BaseHTTPRequestHandler):
                     }
                 )
                 print(f" {_STYLE_SKIP}x{_CLOSE_STYLE_SKIP} Excluding an URL because `{_STYLE_SKIP}{reason_string}{_CLOSE_STYLE_SKIP}`:\n"
-                      f"   {url}") 
+                      f"   {url}")
 
         ###############################################################
         # Prepare the answer and send it
         ###############################################################
-        content = content[:n]  
+        content = content[:n]
         output = json.dumps(dict(response=content)).encode("utf-8")
         self.send_response(200)
         self.send_header("Content-type", "text/html")
@@ -204,21 +247,151 @@ class SearchABC(http.server.BaseHTTPRequestHandler):
             "GoogleSearch."
         )
 
+    def search_bing(
+            self, query: str, n: int, types = ["News"],
+            return_content = True, promote=["News"]
+        ):
+
+        global _bing_subscription_key
+
+        assert _bing_subscription_key
+
+        search_url = "https://api.bing.microsoft.com/v7.0/search"
+        print(f"n={n} responseFilter={types}")
+        headers = {"Ocp-Apim-Subscription-Key": _bing_subscription_key}
+        params = {"q": query, "textDecorations":True,
+            "textFormat": "HTML", "responseFilter":types, 
+            "promote":promote, "answerCount":5}
+        response = requests.get(search_url, headers=headers, params=params)
+        response.raise_for_status()
+        search_results = response.json()
+
+        items = []
+        if "news" in search_results and "value" in search_results["news"]:
+            print(f'bing adding {len(search_results["news"]["value"])} news')
+            items = items + search_results["news"]["value"]
+
+        if "webPages" in search_results and "value" in search_results["webPages"]:
+            print(f'bing adding {len(search_results["webPages"]["value"])} webPages')
+            items = items + search_results["webPages"]["value"]
+
+        if "entities" in search_results and "value" in search_results["entities"]:
+            print(f'bing adding {len(search_results["entities"]["value"])} entities')
+            items = items + search_results["entities"]["value"]
+
+        if "places" in search_results and "value" in search_results["places"]:
+            print(f'bing adding {len(search_results["places"]["value"])} places')
+            items = items + search_results["places"]["value"]
+
+        urls = []
+        contents = []
+        news_count = 0
+
+        for item in items:
+            if "url" not in item:
+                continue
+            else:
+                url = item["url"]
+
+            title = item["name"]
+
+            # Remove Bing formatting characters from title
+            title = filter_html(title)
+
+            if title is None or title == "":
+                print("No title to skipping")
+                continue
+
+            if return_content:
+                content = title + ". "
+                if "snippet" in item :
+                    snippet = filter_html(item["snippet"])
+                    content += snippet
+                    print(f"Adding webpage summary with title {title} for url {url}")
+                    contents.append({'title': title, 'url': url, 'content': content})
+
+                elif "description" in item:
+                    if news_count < 3:
+                        text = filter_html(item["description"])
+                        content += text
+                        news_count += 1
+                        contents.append({'title': title, 'url': url, 'content': content})
+                else:
+                    print(f"Could not find descripton for item {item}")
+            else:
+                urls.append(url)
+
+        if len(urls) == 0 and not return_content:
+           print(f"Warning: No Bing URLs found for query {query}")
+
+        if return_content:
+            return contents
+        else:
+            return urls
+
+def filter_html(title):
+    title.replace("<b>", "")
+    title = title.replace("<b>", "")
+    title = title.replace("</b>", "")
+    title = title.replace("</br>", "")
+    title = title.replace("\u2018", "")
+    title = title.replace("\u2018", "")
+    title = title.replace("\u00b7", "")
+    title = title.replace("&amp", "")
+    title = title.replace("</br>", "")
+    title = title.replace("&#39", "")
+    return title
 
 class GoogleSearchServer(SearchABC):
     def search(self, q: str, n: int) -> Generator[str, None, None]:
-        return googlesearch.search(q, num=n, stop=None, pause=_DELAY_SEARCH, tbs="qdr:m")
-
+        return googlesearch.search(q, num=n, stop=None, pause=_DELAY_SEARCH)
 
 class Application:
-    def serve(self, host: str = _DEFAULT_HOST) -> NoReturn:
+    def serve(
+        self, host: str = _DEFAULT_HOST,
+        requests_get_timeout = _requests_get_timeout,
+        strip_html_menus = _strip_html_menus,
+        max_text_bytes = _max_text_bytes,
+        use_bing = _use_bing,
+        use_bing_description_only = _use_bing_description_only,
+        bing_subscription_key = None) -> NoReturn:
+
+        global _requests_get_timeout, _strip_html_menus, _max_text_bytes
+        global _use_bing, _use_bing_description_only, _bing_subscription_key
+
         """ Main entry point: Start the server.
-        Host is expected to be in the HOSTNAME:PORT format.
-        HOSTNAME can be an IP. Most of the time should be 0.0.0.0.
-        Port 8080 doesn't work on colab.
+        Arguments:
+            host (str):
+            requests_get_timeout (int):
+            strip_html_menus (bool):
+            max_text_bytes (int):
+            use_bing (bool):
+            use_bing_description_only (bool):
+            bing_subscription_key (str):
+        HOSTNAME:PORT of the server. HOSTNAME can be an IP.
+        Most of the time should be 0.0.0.0. Port 8080 doesn't work on colab.
+        Other ports also probably don't work on colab, test it out.
+        requests_get_timeout is seconds before each url fetch times out
+        strip_html_menus removes likely menus to clean up text
+        max_text_bytes limits the bytes returned per web page. Note,
+            ParlAI current defaults to 512 bytes
+        use_bing set to True will use Bing instead of Google
+        use_bing_description_only are short but 10X faster since no url gets
+        bing_subscription_key required to use bing. Can get one at:
+            https://www.microsoft.com/en-us/bing/apis/bing-entity-search-api
         """
+
         hostname, port = _parse_host(host)
         host = f"{hostname}:{port}"
+
+        _requests_get_timeout = requests_get_timeout
+        _strip_html_menus = strip_html_menus
+        _max_text_bytes = max_text_bytes
+        _use_bing = use_bing
+        _use_bing_description_only = use_bing_description_only
+        _bing_subscription_key = bing_subscription_key
+
+        self.check_and_print_cmdline_args()
 
         with http.server.ThreadingHTTPServer(
             (hostname, int(port)), GoogleSearchServer
@@ -227,13 +400,40 @@ class Application:
             print(f"Host: {host}")
             server.serve_forever()
 
+    def check_and_print_cmdline_args(
+        self) -> None:
+        if _use_bing and _bing_subscription_key is None:
+            print("--bing_subscription_key required to use bing search")
+            print("To get one go to url:")
+            print("https://www.microsoft.com/en-us/bing/apis/bing-entity-search-api")
+            exit()
+
+        print("Command line args used:")
+        print(f"  requests_get_timeout={_requests_get_timeout}")
+        print(f"  strip_html_menus={_strip_html_menus}")
+        print(f"  max_text_bytes={_max_text_bytes}")
+        print(f"  use_bing={_use_bing}")
+        print(f"  use_bing_description_only={_use_bing_description_only}")
+
     def test_parser(self, url: str) -> None:
-        """ Test the webpage getter and parser. 
+        """ Test the webpage getter and parser.
         Will try to download the page, then parse it, then will display the result.
         """
         print(_get_and_parse(url))
 
-    def test_server(self, query: str, n: int, host : str = _DEFAULT_HOST) -> None:
+    def test_server(
+            self, query: str, n: int, host : str = _DEFAULT_HOST,
+            requests_get_timeout = _requests_get_timeout,
+            strip_html_menus = _strip_html_menus,
+            max_text_bytes = _max_text_bytes,
+            use_bing = _use_bing,
+            use_bing_description_only = _use_bing_description_only,
+            bing_subscription_key = None
+        ) -> None:
+
+        global _requests_get_timeout, _strip_html_menus, _max_text_bytes
+        global _use_bing, _use_bing_description_only, _bing_subscription_key
+
         """ Creates a thin fake client to test a server that is already up.
         Expects a server to have already been started with `python search_server.py serve [options]`.
         Creates a retriever client the same way ParlAi client does it for its chat bot, then
@@ -241,8 +441,16 @@ class Application:
         """
         host, port = _parse_host(host)
 
+        _requests_get_timeout = requests_get_timeout
+        _strip_html_menus = strip_html_menus
+        _max_text_bytes = max_text_bytes
+        _use_bing = use_bing
+        _use_bing_description_only = use_bing_description_only
+
         print(f"Query: `{query}`")
         print(f"n: {n}")
+
+        self.check_and_print_cmdline_args()
 
         retriever = parlai.agents.rag.retrieve_api.SearchEngineRetriever(
             dict(

--- a/search_server.py
+++ b/search_server.py
@@ -149,14 +149,19 @@ class SearchABCRequestHandler(http.server.BaseHTTPRequestHandler):
                 reason_already_seen_content = (
                     maybe_content["content"] in dupe_detection_set
                 )
+                reason_content_forbidden = (
+                    maybe_content["content"] == "Forbidden"
+                )
             else:
                 reason_content_empty = False
                 reason_already_seen_content = False
-
+                reason_content_forbidden = False
+ 
             reasons = dict(
                 reason_empty_response=reason_empty_response,
                 reason_content_empty=reason_content_empty,
                 reason_already_seen_content=reason_already_seen_content,
+                reason_content_forbidden=reason_content_forbidden,
             )
 
             if not any(reasons.values()):
@@ -178,10 +183,9 @@ class SearchABCRequestHandler(http.server.BaseHTTPRequestHandler):
                 if self.server.strip_html_menus:
                     new_content = ""
                     for line in maybe_content['content'].splitlines():
-                        if line.find("*"): # Performance optimazation since regex is slow
-                            x = re.findall("^[\s]*\\* ", line)
-                            if not x or len(line) > 50:
-                                new_content += line + "\n"
+                        x = re.findall("^[\s]*\\* ", line)
+                        if line != "" and (not x or len(line) > 50):
+                            new_content += line + "\n"
 
                     maybe_content['content'] = filter_special_chars(new_content)
 

--- a/search_server.py
+++ b/search_server.py
@@ -448,15 +448,7 @@ class Application:
         """
         print(_get_and_parse(url))
 
-    def test_server(
-            self, host: str = _DEFAULT_HOST,
-            requests_get_timeout = _REQUESTS_GET_TIMEOUT,
-            strip_html_menus = False,
-            max_text_bytes = None,
-            search_engine = "Google",
-            use_description_only = False,
-            subscription_key = None
-        ) -> NoReturn:
+    def test_server(self, query: str, n: int, host : str = _DEFAULT_HOST) -> None:
 
         """ Creates a thin fake client to test a server that is already up.
         Expects a server to have already been started with `python search_server.py serve [options]`.
@@ -467,9 +459,6 @@ class Application:
 
         print(f"Query: `{query}`")
         print(f"n: {n}")
-
-        self.check_and_print_cmdline_args(max_text_bytes, strip_html_menus,
-            search_server, use_description_only, subscription_key)
 
         retriever = parlai.agents.rag.retrieve_api.SearchEngineRetriever(
             dict(

--- a/search_server.py
+++ b/search_server.py
@@ -29,7 +29,8 @@ _STYLE_GOOD = "[green]"
 _STYLE_SKIP = ""
 _CLOSE_STYLE_GOOD = "[/]" if _STYLE_GOOD else ""
 _CLOSE_STYLE_SKIP = "[/]" if _STYLE_SKIP else ""
-
+_DEFAULT_URL_REQUEST_TIMEOUT = 15 # seconds
+_TRUNCATE_TEXT_BYTES = 2048
 
 def _parse_host(host: str) -> Tuple[str, int]:
     """ Parse the host string. 
@@ -46,7 +47,7 @@ def _get_and_parse(url: str) -> Dict[str, str]:
     """ Download a webpage and parse it. """
 
     try:
-        resp = requests.get(url)
+        resp = requests.get(url, timeout=_DEFAULT_URL_REQUEST_TIMEOUT)
     except requests.exceptions.RequestException as e:
         print(f"[!] {e} for url {url}")
         return None
@@ -161,6 +162,11 @@ class SearchABC(http.server.BaseHTTPRequestHandler):
                     f"   {rich.markup.escape(maybe_content['url'])}"
                     # f"Content: {len(maybe_content['content'])}",
                 )
+
+                # Truncate text 
+                if len(maybe_content) > _TRUNCATE_TEXT_BYTES:
+                    maybe_content = maybe_content[:_TRUNCATE_TEXT_BYTES]
+
                 dupe_detection_set.add(maybe_content["content"])
                 content.append(maybe_content)
                 if len(content) >= n:
@@ -201,7 +207,7 @@ class SearchABC(http.server.BaseHTTPRequestHandler):
 
 class GoogleSearchServer(SearchABC):
     def search(self, q: str, n: int) -> Generator[str, None, None]:
-        return googlesearch.search(q, num=n, stop=None, pause=_DELAY_SEARCH)
+        return googlesearch.search(q, num=n, stop=None, pause=_DELAY_SEARCH, tbs="qdr:m")
 
 
 class Application:


### PR DESCRIPTION
@JulesGM I have implemented all the architectural and stylistic suggestions you requested.  This new pull request adds Bing Search since that was what was used in the ParlAI Blenderbot2 paper.  It also allows you to limit the the text per URL since currently Blenderbot only uses the first 512 characters. It allows you to strip out HTML menus.  You can also return a clean summary of each web page at 10X faster since it does not need to fetch each URL.  I have updated the README with examples to allow you to quickly test these options.  Overall it enables the search engine to return significantly higher quality text to Blenderbot2.   I will send you a separate private email with the URLs to each of these test URLs, which I have deployed as Docker Containers to Google Cloud in case you do not have a Bing Search Subscription key and want to test them.   Thank you again for your time.